### PR TITLE
some optional dependencies like GTK spell

### DIFF
--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -17,6 +17,38 @@ finish-args:
 #needs network access for maps
   - --share=network
 modules:
+  - name: enchant-ver1
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/AbiWord/enchant/releases/download/enchant-1-6-1/enchant-1.6.1.tar.gz
+        sha256: bef0d9c0fef2e4e8746956b68e4d6c6641f6b85bd2908d91731efb68eba9e3f5
+
+  - name: intltool
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+
+  - name: gtk-spell
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://sourceforge.net/projects/gtkspell/files/3.0.10/gtkspell3-3.0.10.tar.xz
+        sha256: b040f63836b347eb344f5542443dc254621805072f7141d49c067ecb5a375732
+
+  - name: python-fontconfig
+    buildsystem: simple
+    ensure-writable:
+      - /lib/python3.8/site-packages/easy-install.pth
+    build-commands:
+      - python3 setup.py install --prefix=/app
+    sources:
+      - type: archive
+        url: https://github.com/ldo/python_fontconfig/archive/v0.7.tar.gz
+        sha256: 44d3f1597afae0720c02d2504105c5c2b074f2e6bc017f3c73fe33559e571e3b
+
   - name: BSDDB3
     subdir: dist
     builddir: true
@@ -107,7 +139,6 @@ modules:
     ensure-writable:
       - /lib/python3.8/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py build --build-base=/app
       - python3 setup.py install --prefix=/app --exec-prefix=/bin
       - install -Dm644 /app/share/icons/gramps.png -t /app/share/icons/hicolor/48x48/apps/
       - install -Dm644 /app/share/gramps/images/gramps.svg -t /app/share/icons/hicolor/scalable/apps/


### PR DESCRIPTION
1. took out unnecessary build command in Gramps
2. added the optional python-fontconfig dependency to allow more user addons to work
3. manually added a different version of enchant because the Gramps flatpak did not find the version used in the Platform or SDK
4. manually added a newer version of intltool than included with the Platform or SDK to resolve a compiling error
5. manually added GTK spell since it was not found by the Gramps flatpak from the Platform or SDK