### PR TITLE
Graphview addon dependencies, reorganize manifest

### DIFF
--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -23,6 +23,39 @@ finish-args:
 #needs network access for maps
   - --share=network
 modules:
+# following dependencies are for the GraphView Addon
+  - name: PGIDependency
+    buildsystem: simple
+    build-commands:
+      - python3 setup.py install --prefix=/app
+    sources:
+      - type: archive
+        url:  https://github.com/pygobject/pgi/archive/0.0.11.2.tar.gz
+        sha256:  7a1ca8ac4e8bee6b663e6d556ecda8032584de753acd76ab3fc21c4f874fa738
+
+  - name: PygobjectDependency
+    buildsystem: meson
+    config-opts:
+      - --prefix=/app
+    sources:
+      - type: archive
+        url:  https://gitlab.gnome.org/GNOME/pygobject/-/archive/pygobject-3-38/pygobject-pygobject-3-38.tar.gz
+        sha256:  5b2f653a100fd7b417f40439600330056b99fb7887d8048c24463a38049bcf1b
+
+  - name: GoocanvasDependency
+    buildsystem: autotools
+    config-opts:
+      - --prefix=/app
+    make-install-args:
+      - pyoverridesdir=/app/lib/python3.8/site-packages/gi/overrides
+      - typelibdir=/app/lib/girepository-1.0
+    sources:
+      - type: archive
+        url:  https://download.gnome.org/sources/goocanvas/2.0/goocanvas-2.0.4.tar.xz
+        sha256:  c728e2b7d4425ae81b54e1e07a3d3c8a4bd6377a63cffa43006045bceaa92e90
+
+# gramps 5.1.3 does not seem to recognize enchant2 included with sdk or platform
+# following dependencies are for spell check    
   - name: enchant-ver1
     buildsystem: autotools
     sources:
@@ -44,17 +77,7 @@ modules:
         url: https://sourceforge.net/projects/gtkspell/files/3.0.10/gtkspell3-3.0.10.tar.xz
         sha256: b040f63836b347eb344f5542443dc254621805072f7141d49c067ecb5a375732
 
-  - name: python-fontconfig
-    buildsystem: simple
-    ensure-writable:
-      - /lib/python3.8/site-packages/easy-install.pth
-    build-commands:
-      - python3 setup.py install --prefix=/app
-    sources:
-      - type: archive
-        url: https://github.com/ldo/python_fontconfig/archive/v0.7.tar.gz
-        sha256: 44d3f1597afae0720c02d2504105c5c2b074f2e6bc017f3c73fe33559e571e3b
-
+# following dependencies are for the old Berkeley database
   - name: BSDDB3
     subdir: dist
     builddir: true
@@ -70,6 +93,7 @@ modules:
         sha256: e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628
       - type: patch
         path: atomic.patch
+        # for aarch64 
       - type: shell
         commands:
           - cp -p /usr/share/automake-*/config.{sub,guess} dist
@@ -87,13 +111,7 @@ modules:
         url: https://files.pythonhosted.org/packages/source/b/bsddb3/bsddb3-6.2.7.tar.gz
         sha256: b0f7fa63eb240cd5815809c9d1d7df9f7cc8d6fa9619d0edbe9c794afc02dc9f
 
-  - name: osmgpsmapDependency
-    buildsystem: autotools
-    sources:
-       - type: archive
-         url:  https://github.com/nzjrs/osm-gps-map/releases/download/1.1.0/osm-gps-map-1.1.0.tar.gz
-         sha256:  8f2ff865ed9ed9786cc5373c37b341b876958416139d0065ebb785cf88d33586
-
+# following dependencies are for images
   - name: exiv2Dependency
     buildsystem: cmake
     sources:
@@ -109,11 +127,30 @@ modules:
   - name: gexiv2Dependency
     buildsystem: meson
     config-opts:
-      - -Dpython3_girdir=no
+      - -Dpython3_girdir=/app/lib/python3.8/site-packages/gi/overrides
     sources:
       - type: archive
         url:  https://download.gnome.org/sources/gexiv2/0.12/gexiv2-0.12.1.tar.xz
         sha256:  8aeafd59653ea88f6b78cb03780ee9fd61a2f993070c5f0d0976bed93ac2bd77
+
+# following dependencies are for geography and charts
+  - name: python-fontconfig
+    buildsystem: simple
+    ensure-writable:
+      - /lib/python3.8/site-packages/easy-install.pth
+    build-commands:
+      - python3 setup.py install --prefix=/app
+    sources:
+      - type: archive
+        url: https://github.com/ldo/python_fontconfig/archive/v0.7.tar.gz
+        sha256: 44d3f1597afae0720c02d2504105c5c2b074f2e6bc017f3c73fe33559e571e3b
+
+  - name: osmgpsmapDependency
+    buildsystem: autotools
+    sources:
+       - type: archive
+         url:  https://github.com/nzjrs/osm-gps-map/releases/download/1.1.0/osm-gps-map-1.1.0.tar.gz
+         sha256:  8f2ff865ed9ed9786cc5373c37b341b876958416139d0065ebb785cf88d33586
 
   - name: PyICUDependency
     buildsystem: simple
@@ -140,6 +177,7 @@ modules:
         url:  https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9533/ghostscript-9.53.3.tar.gz
         sha256:  6eaf422f26a81854a230b80fd18aaef7e8d94d661485bd2e97e695b9dce7bf7f
 
+# Gramps
   - name: Gramps
     buildsystem: simple
     ensure-writable:


### PR DESCRIPTION
1. Add dependencies for the optional Graphview add-on
2. Reorganize manifest with more comments explaining groups of dependencies