### PR TITLE
update to Gramps 5.1.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/org.gramps_project.Gramps.metainfo.xml
+++ b/org.gramps_project.Gramps.metainfo.xml
@@ -203,6 +203,8 @@
 
   <content_rating type="oars-1.1"/>
   <releases>
+    <release date="2022-02-14" version="5.1.5-1"/>
+    <release date="2022-02-05" version="5.1.5"/>
     <release date="2022-01-14" version="5.1.4-3"/>
     <release date="2021-11-22" version="5.1.4-2"/>
     <release date="2021-07-28" version="5.1.4-1"/>

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -85,12 +85,14 @@ modules:
 
 # following dependencies are for the old Berkeley database, Oracle took over in later versions
   - name: BSDDB3
-    buildsystem: simple
-    build-commands:
-      - cd build_unix
-      - ./dist/configure --prefix=/app --enable-compat185 --enable-shared --enable-cxx -enable-dbm --enable-stl
-      - make
-      - make docdir=/app/share install
+    subdir: dist
+    builddir: true
+    config-opts:
+      - --enable-compat185
+      - --enable-shared
+      - --enable-cxx
+      - --enable-dbm
+      - --enable-stl
     sources:
       - type: archive
         url: https://download.oracle.com/berkeley-db/db-5.3.28.tar.gz
@@ -98,6 +100,9 @@ modules:
       - type: patch
         path: atomic.patch
         # for aarch64 
+      - type: shell
+        commands:
+          - cp -p /usr/share/automake-*/config.{sub,guess} dist
 
    #python3-bsddb deprecated and does not work after python3.9, must use berkeleydb
   - name: python3-bsddb

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -1,11 +1,14 @@
 app-id: org.gramps_project.Gramps
 # flatpak-builder will not take com.gramps-project.Gramps
 runtime: org.gnome.Platform
-runtime-version: '41'
+runtime-version: '40'
 sdk: org.gnome.Sdk
 command: gramps
 rename-icon: gramps
 rename-desktop-file: gramps.desktop
+# no-debuginfo to prevent Github Actions workflow from getting stuck, it causes errors
+build-options:
+  no-debuginfo: true
 finish-args:
 # Gramps installs media files from backups to home, so it needs home access for now
 #  - --filesystem=xdg-documents
@@ -34,7 +37,7 @@ modules:
   - name: PILLOWDependency
     buildsystem: simple
     build-commands:
-      - python3 setup.py install --prefix=/app
+      - pip3 install --no-deps --no-use-pep517 --prefix=/app .
     sources:
       - type: archive
         url:  https://files.pythonhosted.org/packages/8f/7d/1e9c2d8989c209edfd10f878da1af956059a1caab498e5bc34fa11b83f71/Pillow-8.3.1.tar.gz
@@ -46,7 +49,7 @@ modules:
     config-opts:
       - --prefix=/app
     make-install-args:
-      - pyoverridesdir=/app/lib/python3.9/site-packages/gi/overrides
+      - pyoverridesdir=/app/lib/python3.8/site-packages/gi/overrides
       - typelibdir=/app/lib/girepository-1.0
     sources:
       - type: archive
@@ -57,17 +60,20 @@ modules:
   # pyenchant most recent version as of 202107 was from 202106
   - name: pyenchantDependency
     buildsystem: simple
-    ensure-writable:
-      - /lib/python3.9/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py install --prefix=/app
+      - pip3 install --no-deps --no-use-pep517 --prefix=/app .
     sources:
       - type: archive
         url:  https://files.pythonhosted.org/packages/63/c3/074c9c4d6c39b26e8d06316b698995ee11ccfe0332f684d133f33126bd69/pyenchant-3.2.1.tar.gz
         sha256:  5e206a1d6596904a922496f6c9f7d0b964b243905f401f5f2f40ea4d1f74e2cf
 
     # intltool most recent version as of 202104 was from 2015
-  - shared-modules/intltool/intltool-0.51.json
+  - name: intltool
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
 
     # GTK-Spell most recent version as of 202104 was from 2018
   - name: gtk-spell
@@ -79,14 +85,12 @@ modules:
 
 # following dependencies are for the old Berkeley database, Oracle took over in later versions
   - name: BSDDB3
-    subdir: dist
-    builddir: true
-    config-opts:
-      - --enable-compat185
-      - --enable-shared
-      - --enable-cxx
-      - --enable-dbm
-      - --enable-stl
+    buildsystem: simple
+    build-commands:
+      - cd build_unix
+      - ./dist/configure --prefix=/app --enable-compat185 --enable-shared --enable-cxx -enable-dbm --enable-stl
+      - make
+      - make docdir=/app/share install
     sources:
       - type: archive
         url: https://download.oracle.com/berkeley-db/db-5.3.28.tar.gz
@@ -94,20 +98,16 @@ modules:
       - type: patch
         path: atomic.patch
         # for aarch64 
-      - type: shell
-        commands:
-          - cp -p /usr/share/automake-*/config.{sub,guess} dist
 
+   #python3-bsddb deprecated and does not work after python3.9, must use berkeleydb
   - name: python3-bsddb
     buildsystem: simple
-    ensure-writable:
-      - /lib/python3.9/site-packages/easy-install.pth
     build-options:
+      no-debuginfo: true
       env:
         BERKELEYDB_DIR: /app
     build-commands:
-      - python3 setup.py build
-      - python3 setup.py install --prefix=/app
+      - pip3 install --no-deps --no-use-pep517 --prefix=/app .
     sources:
       - type: archive
         url: https://files.pythonhosted.org/packages/source/b/bsddb3/bsddb3-6.2.7.tar.gz
@@ -121,14 +121,14 @@ modules:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: archive
-        url:  https://www.exiv2.org/builds/exiv2-0.27.5-Source.tar.gz
+        url:  https://github.com/Exiv2/exiv2/releases/download/v0.27.5/exiv2-0.27.5-Source.tar.gz
         sha256: 35a58618ab236a901ca4928b0ad8b31007ebdc0386d904409d825024e45ea6e2
 
     # gexiv2 most recent version as of 202104 was from 202102
   - name: gexiv2Dependency
     buildsystem: meson
     config-opts:
-      - -Dpython3_girdir=/app/lib/python3.9/site-packages/gi/overrides
+      - -Dpython3_girdir=/app/lib/python3.8/site-packages/gi/overrides
     sources:
       - type: archive
         url:  https://download-fallback.gnome.org/sources/gexiv2/0.12/gexiv2-0.12.2.tar.xz
@@ -138,10 +138,8 @@ modules:
     # python-fontconfig most recent version as of 202104 was 201909
   - name: python-fontconfig
     buildsystem: simple
-    ensure-writable:
-      - /lib/python3.9/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py install --prefix=/app
+      - pip3 install --no-deps --no-use-pep517 --prefix=/app .
     sources:
       - type: archive
         url: https://github.com/ldo/python_fontconfig/archive/v0.7.tar.gz
@@ -157,6 +155,7 @@ modules:
 
     # Gramps does not see geocodeglib in platform, needed for place coordinate addon
     # appears to not have versioned releases anymore, last git edit as of 202110 was from 202109
+    # geocodeglib appears to have changed prerequisites and needs to be commented out for now to allow Gramps to compile
   - name: geocodeglibDependency
     buildsystem: meson
     sources:
@@ -167,10 +166,8 @@ modules:
     # pyicu most recent release as of 202104 was from 202104
   - name: PyICUDependency
     buildsystem: simple
-    ensure-writable:
-      - /lib/python3.9/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py install --prefix=/app
+      - pip3 install --no-deps --no-use-pep517 --prefix=/app .
     sources:
       - type: archive
         url:  https://files.pythonhosted.org/packages/17/0f/9d6b7eb01650960239a5d4dc21cd6e7a96921807c043d287bae4b2f440e1/PyICU-2.7.2.tar.gz
@@ -196,10 +193,8 @@ modules:
     # decorator most recent version as of 202104 was from 202104
   - name: decoratorDependency
     buildsystem: simple
-    ensure-writable:
-      - /lib/python3.9/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py install --prefix=/app
+      - pip3 install --no-deps --no-use-pep517 --prefix=/app .
     sources:
       - type: archive
         url:  https://files.pythonhosted.org/packages/a9/09/dd085a8afcf48fdaba851fe10956d5dbf1e9091206f7ca717223563f75c2/decorator-5.0.7.tar.gz
@@ -208,10 +203,8 @@ modules:
     # networkx most recent stable version as of 202104 was from 202008
   - name: networkxDependency
     buildsystem: simple
-    ensure-writable:
-      - /lib/python3.9/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py install --prefix=/app
+      - pip3 install --no-deps --no-use-pep517 --prefix=/app .
     sources:
       - type: archive
         url:  https://files.pythonhosted.org/packages/ef/d0/f706a9e5814a42c544fa1b2876fc33e5d17e1f2c92a5361776632c4f41ab/networkx-2.5.tar.gz
@@ -220,10 +213,8 @@ modules:
     # pygraphviz most recent stable version as of 202104 was from 202102
   - name: pyGraphvizDependency
     buildsystem: simple
-    ensure-writable:
-      - /lib/python3.9/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py install --prefix=/app
+      - pip3 install --no-deps --no-use-pep517 --prefix=/app .
     sources:
       - type: archive
         url:  https://files.pythonhosted.org/packages/3a/d6/2c56f09ee83dbebb62c40487e4c972135661b9984fec9b30b77fb497090c/pygraphviz-1.7.zip
@@ -232,15 +223,13 @@ modules:
 # Gramps
   - name: Gramps
     buildsystem: simple
-    ensure-writable:
-      - /lib/python3.9/site-packages/easy-install.pth
     build-commands:
       - python3 setup.py install --prefix=/app
       - install -Dm644 org.gramps_project.Gramps.metainfo.xml -t /app/share/metainfo/
       - mv ${FLATPAK_DEST}/share/mime/packages/gramps.xml ${FLATPAK_DEST}/share/mime/packages/${FLATPAK_ID}.xml
     sources:
       - type: archive
-        url:  https://github.com/gramps-project/gramps/archive/refs/tags/v5.1.4.tar.gz
-        sha256:  6e64a5c1175a4897256ca9eb73a4b77c8e84ebff020b8668bdc527d6dcd14273
+        url:  https://github.com/gramps-project/gramps/archive/refs/tags/v5.1.5.tar.gz
+        sha256:  4045a142a7c3cbe50a41e594bb160dce4112e37ef7dec68d65af42e9269c2df6
       - type: file
         path:  org.gramps_project.Gramps.metainfo.xml


### PR DESCRIPTION
-update Gramps to 5.1.5, which contains bug fixes
-revert to Gnome Platform 40 because trouble with setting resource path in Platform 41
-remove submodules to get back to upstream, since I have trouble running workflows with submodules
-changed most modules to pip commands in effort to get Gramps to work with the current python in Gnome Platform 41, but with setup.py now deprecated in 41 I was not able to set the resource path with pip.  So Gramps would not launch unless it was installed with setup.py.  please see the following for more details:
https://github.com/gramps-project/flatpak/issues/22
https://discourse.flathub.org/t/how-to-set-resource-path-in-flatpak-manifest-for-pip-install/2202
https://discourse.flathub.org/t/setup-py-install-deprecated-must-use-pip/2177