### PR TITLE
turn off debugging again

### DIFF
--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -6,6 +6,9 @@ sdk: org.gnome.Sdk
 command: gramps
 rename-icon: gramps
 rename-desktop-file: gramps.desktop
+# no-debuginfo to prevent Github Actions workflow from getting stuck, it causes errors
+build-options:
+  no-debuginfo: true
 finish-args:
 # Gramps installs media files from backups to home, so it needs home access for now
 #  - --filesystem=xdg-documents


### PR DESCRIPTION
allowing debugging appears to have cause the workflow for arch64 to fail