### PR TITLE
5.2.0-1 to allow access to ~/.gramps and others that system installs use, for user convenience

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Gramps flatpak 5.2.0-1
+  - add file access to xdg-data, xdg-config, xdg-cache, and ~/.gramps
+
 Gramps flatpak 5.2.0-0
   - update Gramps source to 5.2.0 and update sha256
   - remove flatpak's home directory access in favor of xdg access for Docs, Downloads, and Pictures

--- a/org.gramps_project.Gramps.metainfo.xml
+++ b/org.gramps_project.Gramps.metainfo.xml
@@ -203,6 +203,7 @@
 
   <content_rating type="oars-1.1"/>
   <releases>
+    <release date="2024-03-09" version="5.2.0-1"/>
     <release date="2024-02-24" version="5.2.0-0"/>
     <release date="2023-06-30" version="5.1.6-1"/>
     <release date="2023-03-25" version="5.1.5-5"/>

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -10,9 +10,6 @@ finish-args:
   - --filesystem=xdg-pictures
 # for data directories and backwards compatibility  
   - --filesystem=~/.gramps:create
-  - --filesystem=xdg-data
-  - --filesystem=xdg-config
-  - --filesystem=xdg-cache
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -10,7 +10,10 @@ finish-args:
   - --filesystem=xdg-pictures
 # for data directories and backwards compatibility  
   - --filesystem=~/.gramps:create
-# needs to own upstream name
+  - --filesystem=~/.local/share:create
+  - --filesystem=~/.config:create
+  - --filesystem=~/.cache:create
+  # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui
   - --socket=wayland

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -8,7 +8,11 @@ finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --filesystem=xdg-pictures
-#  - --filesystem=~/.gramps:create
+# for data directories and backwards compatibility  
+  - --filesystem=~/.gramps:create
+  - --filesystem=xdg-data
+  - --filesystem=xdg-config
+  - --filesystem=xdg-cache
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui


### PR DESCRIPTION
There were some user issues from restricting the flatpak from home access in 5.1.6 down to Pictures, Documents, and Downloads in 5.2