### PR TITLE
bug fix: restore home access due to user data loss

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 Gramps flatpak 5.2.0-1
-  - add file access to xdg-data, xdg-config, xdg-cache, and ~/.gramps
+  - bug fix: restore home access due to user data loss
 
 Gramps flatpak 5.2.0-0
   - update Gramps source to 5.2.0 and update sha256

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://github.com/gramps-project/flatpak
 https://github.com/flathub/org.gramps_project.Gramps
 
 ***Please Note***
-For now, both attempts to use specific xdg directories have caused problems for users of the Gramps flatpak.
+Posting new issues to drop home access can not be complied with at this time. Both attempts to use specific xdg directories have caused problems for users of the Gramps flatpak.
 At this time, flathub rules blocking data directory access prevents users from choosing to go between a flatpak
 installation and a system installation, which causes data loss for some users. Even using persist like flathub says
 instead of filesystem can cause data loss for users moving from the flatpak to a system install. The required directories for databases started 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ https://github.com/gramps-project/flatpak
 https://github.com/flathub/org.gramps_project.Gramps
 
 ***Please Note***
-For security reasons, the flatpak for Gramps 5.2 will lose access to the entire home directory in exchange for xdg access to only Documents, Downloads, and Pictures. If your media directory for Gramps is not in Documents, Downloads, or Pictures, then you can either:
-1. Move your media directory to either Documents, Downloads, or Pictures, and then use the Media Tool in Gramps to change the path so that Gramps can see the media again
-2. Use flatseal (a flatpak permissions app available at flathub) to allow Gramps access to whereever your media directory is located.
-3. If the 5.2 version of Gramps does not show your tree, then close Gramps, open your file browser to the directory that the .gramps file (or .gpkg file if a backup), right click on the file, and select "Open with Gramps". It will take a couple minutes to convert to the 5.2 version, but it should work as long as you make sure the file and all related pictures are in Documents, Pictures, or Downloads.
+For now, both attempts to use specific xdg directories have caused problems for users of the Gramps flatpak.
+At this time, flathub rules blocking data directory access prevents users from choosing to go between a flatpak
+installation and a system installation, which causes data loss for some users. Even using persist like flathub says
+instead of filesystem can cause data loss for users moving from the flatpak to a system install. The required directories for databases started 
+with Gramps 5.1 and earlier is ~/.gramps, while the required directories for databases started with a system installation 
+of Gramps 5.2 are xdg-data, xdg-config, xdg-cache. Once flathub stops blocking these directories, we can remove home
+directory access and go back to xdg access.
 
 Also, the old version of Berkeley Database (BSDDB) that was included with the Gramps 5.0 and 5.1 flatpaks will be dropped for 5.2.
 

--- a/org.gramps_project.Gramps.metainfo.xml
+++ b/org.gramps_project.Gramps.metainfo.xml
@@ -203,7 +203,7 @@
 
   <content_rating type="oars-1.1"/>
   <releases>
-    <release date="2024-03-09" version="5.2.0-1"/>
+    <release date="2024-03-11" version="5.2.0-1"/>
     <release date="2024-02-24" version="5.2.0-0"/>
     <release date="2023-06-30" version="5.1.6-1"/>
     <release date="2023-03-25" version="5.1.5-5"/>

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -5,14 +5,21 @@ runtime-version: '45'
 sdk: org.gnome.Sdk
 command: gramps
 finish-args:
-  - --filesystem=xdg-documents
-  - --filesystem=xdg-download
-  - --filesystem=xdg-pictures
-# for data directories and backwards compatibility  
-  - --filesystem=~/.gramps:create
-  - --filesystem=~/.local/share:create
-  - --filesystem=~/.config:create
-  - --filesystem=~/.cache:create
+  - --filesystem=home
+# for now, flathub rules blocking the data directories prevent users from choosing to go between a flatpak
+# installation and a system installation. This can cause user data loss, even using persist instead of filesystem
+# can cause data loss for users moving from the flatpak to a system install. When flathub changes thier rules, 
+# home access can be removed and the below filesystems permissiong can be used
+#  - --filesystem=xdg-documents
+#  - --filesystem=xdg-download
+#  - --filesystem=xdg-pictures
+# for data directories and compatibility with system installs, flathub currently blocks these directories
+ # for databases started with 5.1 and earlier
+#  - --filesystem=~/.gramps:create
+ # for databases started with 5.2 system installations
+#  - --filesystem=xdg-data
+#  - --filesystem=xdg-config
+#  - --filesystem=xdg-cache
   # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui


### PR DESCRIPTION
xdg access to databases is blocked, and using persist breaks compatibility going from the flatpak to a system installation