### PR TITLE
if xdg access is permitted in future, the create option is needed

### DIFF
--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -9,17 +9,17 @@ finish-args:
 # for now, flathub rules blocking the data directories prevent users from choosing to go between a flatpak
 # installation and a system installation. This can cause user data loss, even using persist instead of filesystem
 # can cause data loss for users moving from the flatpak to a system install. When flathub changes thier rules, 
-# home access can be removed and the below filesystems permissiong can be used
-#  - --filesystem=xdg-documents
+# home access can be removed and the below filesystems permissions can be used
+#  - --filesystem=xdg-documents:create
 #  - --filesystem=xdg-download
 #  - --filesystem=xdg-pictures
 # for data directories and compatibility with system installs, flathub currently blocks these directories
  # for databases started with 5.1 and earlier
 #  - --filesystem=~/.gramps:create
  # for databases started with 5.2 system installations
-#  - --filesystem=xdg-data
-#  - --filesystem=xdg-config
-#  - --filesystem=xdg-cache
+#  - --filesystem=xdg-data:create
+#  - --filesystem=xdg-config:create
+#  - --filesystem=xdg-cache:create
   # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui


### PR DESCRIPTION
in commented out lines, add create option to xdg-documents, xdg-data, xdg-config, and xdg-cache so that I don't forget to add it later.

fixed typo