### PR TITLE
5.2.3-0 flatpak

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Gramps flatpak 5.2.3-0
+  - update Gramps source to 5.2.3 and update sha256sum
+
 Gramps flatpak 5.2.2-0
   - update Gramps source to 5.2.2
   - update Gnome runtime to 46

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -197,5 +197,5 @@ modules:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url:  https://github.com/gramps-project/gramps/archive/refs/tags/v5.2.2.tar.gz
-        sha256:  340cfe136f428cd185d510ca8f932401633e0014eba0261159c4b21efe92a126
+        url:  https://github.com/gramps-project/gramps/archive/refs/tags/v5.2.3.tar.gz
+        sha256:  bd1b7dc3f26ffd480f607a79e3a76688024a28b0f0b412ac1e4d77402ddc87d6


### PR DESCRIPTION
PR will wait about a week on gramps project github review, but is submitted now to check for compiling errors here since flathub uses a different workflow than me.

Changes are just the gramps source and sha256sum