### PR TITLE
Gramps source update to 5.2.4

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Gramps flatpak 5.2.4-0
+  - update Gramps source and sha256 to Gramps 5.2.4
+
 Gramps flatpak 5.2.3-1
   - update Gnome runtime to 47
   - update to goocanvas 3.0.0 because a patch exists for it to work

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -207,5 +207,5 @@ modules:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url:  https://github.com/gramps-project/gramps/archive/refs/tags/v5.2.3.tar.gz
-        sha256:  bd1b7dc3f26ffd480f607a79e3a76688024a28b0f0b412ac1e4d77402ddc87d6
+        url:  https://github.com/gramps-project/gramps/archive/refs/tags/v5.2.4.tar.gz
+        sha256:  7d5f22db92c43cb7798b50837e95ee5da56154596d9dea3b96d2c5cd2e5f0cdd


### PR DESCRIPTION
This will be pushed to main in about a week to allow Gramps project time to review. I made the PR now to verify that the flathub compiler has no problems with this manifest.