### PR TITLE
gramps 6.0.0-0 update

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 Gramps flatpak 6.0.0-0
   - update Gramps source and sha256 to 6.0.0
   - update Gnome Platform to 48
-  - add orjson version 3.9.15 since 3.10.15 does not compile in flatpak
+  - add orjson 3.10.15 with separate arch64 and x86_64 wheels
   - update exiv2 to 0.28.5
   - update gexiv2 to 0.14.3
   - update PILLOW to 11.1.0

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,19 @@
+Gramps flatpak 6.0.0-0
+  - update Gramps source and sha256 to 6.0.0
+  - update Gnome Platform to 48
+  - add orjson version 3.9.15 since 3.10.15 does not compile in flatpak
+  - update exiv2 to 0.28.5
+  - update gexiv2 to 0.14.3
+  - update PILLOW to 11.1.0
+  - update gspell to 1.14.0
+  - removed python-fontconfig since its requirement got dropped in Gramps 5.2
+  - update pyicu to 2.14
+  - update graphviz to 12.2.1
+  - update pygraphviz to 1.14
+  - update ghostscriptpdl to 10.05.0
+  - remove decorator dependency
+  - update networkx to 3.4.2
+
 Gramps flatpak 5.2.4-0
   - update Gramps source and sha256 to Gramps 5.2.4
 

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -1,7 +1,7 @@
 app-id: org.gramps_project.Gramps
 # flatpak-builder will not take hyphen in com.gramps-project.Gramps
 runtime: org.gnome.Platform
-runtime-version: '47'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 command: gramps
 # to force an archive flatpak to use system locale instead of English. Not needed for flathub packages.
@@ -44,15 +44,15 @@ cleanup:
   - /share/gir-1.0
   - /share/man
 modules:
-# PILLOW for cropping images, latex support, and addons; most recent version as of 2024.03 is from 2024.01
+# PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple
     build-commands:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url:  https://files.pythonhosted.org/packages/source/p/pillow/pillow-10.2.0.tar.gz
-        sha256:  e87f0b2c78157e12d7686b27d63c070fd65d994e8ddae6f328e0dcf4a0cd007e
+        url:  https://files.pythonhosted.org/packages/f3/af/c097e544e7bd278333db77933e535098c259609c4eb3b85381109602fb5b/pillow-11.1.0.tar.gz
+        sha256:  368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20
 
     # Goocanvas is abandoned and the most recent update is from 2021.01.16.
   - name: GoocanvasDependency
@@ -69,18 +69,16 @@ modules:
       - type: patch
         path: goocanvas-3.0.0-gcc14.patch
 
-# following dependencies are for spell check
-    # Gspell most recent version as of 2024.03 was from 2023.07
+    # Gspell most recent version as of 2025.03 was from 2024.09
   - name: gspell
-    cleanup:
-      - /bin
-    sources:
+    buildsystem: meson
+    sources: 
       - type: archive
-        url: https://download.gnome.org/sources/gspell/1.12/gspell-1.12.2.tar.xz
-        sha256: b4e993bd827e4ceb6a770b1b5e8950fce3be9c8b2b0cbeb22fdf992808dd2139
+        url: https://gitlab.gnome.org/GNOME/gspell/-/archive/1.14.0/gspell-1.14.0.tar.gz
+        sha256: 6ff11258569227c4ef0eaed0524e0c9f84308d34f89fbc49e5d961cdd832ac6a
 
 # following dependencies are for images and metadata
-    # exiv2 most recent version as of 2024.03 was from 2024.02
+    # exiv2 most recent version as of 2025.03 was from 2025.02
   - name: exiv2
     buildsystem: cmake-ninja
     config-opts:
@@ -89,10 +87,10 @@ modules:
     builddir: true
     sources:
       - type: archive
-        url:  https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.2.tar.gz
-        sha256: 543bead934135f20f438e0b6d8858c55c5fcb7ff80f5d1d55489965f1aad58b9
+        url:  https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.5.tar.gz
+        sha256: e1671f744e379a87ba0c984617406fdf8c0ad0c594e5122f525b2fb7c28d394d
 
-    # gexiv2 most recent from 2023July as of 2024Feb
+    # gexiv2 most recent version as of 2025.03 was from 2024.06
     # gramps apparently needs introspection to use gexiv2
   - name: gexiv2Dependency
     buildsystem: meson
@@ -102,19 +100,8 @@ modules:
         - -PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR=/app/lib/girepository-1.0
     sources:
       - type: archive
-        url:  https://download.gnome.org/sources/gexiv2/0.14/gexiv2-0.14.2.tar.xz
-        sha256:  2a0c9cf48fbe8b3435008866ffd40b8eddb0667d2212b42396fdf688e93ce0be
-
-# following dependencies are for geography and charts
-    # python-fontconfig most recent version as of 202104 was 201909
-  - name: python-fontconfig
-    buildsystem: simple
-    build-commands:
-      - pip3 install --no-build-isolation .
-    sources:
-      - type: archive
-        url: https://github.com/ldo/python_fontconfig/archive/v0.7.tar.gz
-        sha256: 44d3f1597afae0720c02d2504105c5c2b074f2e6bc017f3c73fe33559e571e3b
+        url:  https://gitlab.gnome.org/GNOME/gexiv2/-/archive/gexiv2-0.14.3/gexiv2-gexiv2-0.14.3.tar.gz
+        sha256:  5a7ea82effa9c812ac1518a1b4a22a15035d721b0b30cd4b8303228fd5b38e3c
 
    # osmgpsmap dependency 1.2 as of 2023-06 requires libsoup 2.4. 
    # Libsoup 2 is not in Gnome 44 runtime as of 2023-06, so libsoup needs a manual install until
@@ -126,7 +113,7 @@ modules:
         url: https://download.gnome.org/sources/libsoup/2.74/libsoup-2.74.3.tar.xz
         sha256: e4b77c41cfc4c8c5a035fcdc320c7bc6cfb75ef7c5a034153df1413fa1d92f13
 
-    # osmgpsmap most recent version as of 202104 was from 202102
+    # osmgpsmap is abandoned as of 2025.03 so most recent version was from 202102
   - name: osmgpsmapDependency
     buildsystem: autotools
     sources:
@@ -135,7 +122,7 @@ modules:
         sha256:  ddec11449f37b5dffb4bca134d024623897c6140af1f9981a8acc512dbf6a7a5
 
     # Gramps does not see geocodeglib in platform, needed for place coordinate addon
-    # appears to not have versioned releases anymore, last git edit as of 2024.03 was from 2024.03
+    # appears to not have versioned releases anymore, last git edit as of 2025.03 was from 2024.03
   - name: geocodeglibDependency
     buildsystem: meson
     sources:
@@ -143,25 +130,25 @@ modules:
         url:  https://gitlab.gnome.org/GNOME/geocode-glib/-/archive/8f1b5a9149156a03f62dfea14780e8fee030506d/geocode-glib-8f1b5a9149156a03f62dfea14780e8fee030506d.tar.gz
         sha256:  f4ea933937633d6e33607945c9ca45070628e8545be0ea502b59f959932e8b26
 
-    # pyicu most recent release as of 2024.03 was from 2023.11
+    # pyicu most recent release as of 2025.03 was from 2024.10
   - name: PyICUDependency
     buildsystem: simple
     build-commands:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url:  https://files.pythonhosted.org/packages/source/P/PyICU/PyICU-2.12.tar.gz
-        sha256:  bd7ab5efa93ad692e6daa29cd249364e521218329221726a113ca3cb281c8611
+        url: https://files.pythonhosted.org/packages/52/21/4e9b0a3ace3027fc63107fa2b5d6e66e321e104da071d787856962fbad52/PyICU-2.14.tar.gz
+        sha256: acc7eb92bd5c554ed577249c6978450a4feda0aa6f01470152b3a7b382a02132
 
-    # graphviz most recent version as of 2024Feb from 2024Feb
+    # graphviz most recent version as of 2025.03 from 2024.12
   - name: GraphVizDependency
     buildsystem: autotools
     sources:
       - type: archive
-        url: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/10.0.1/graphviz-10.0.1.tar.xz
-        sha256:  7bd8064a94bc178862aa0fbb0ed2236f49c188b2fd656487247c58db3019fe21
+        url: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.1/graphviz-12.2.1.tar.gz
+        sha256: 242bc18942eebda6db4039f108f387ec97856fc91ba47f21e89341c34b554df8
 
-    # pygraphviz 1.14 most recent version 2024.09.29 as of 2024.12.23
+    # pygraphviz 1.14 most recent version 2024.09.29 as of 2025.03
   - name: PyGraphVizDependency
     buildsystem: simple
     build-commands:
@@ -171,35 +158,35 @@ modules:
         url: https://github.com/pygraphviz/pygraphviz/archive/refs/tags/pygraphviz-1.14.tar.gz
         sha256:  d9a43f34b920367fa89a2598083b47db42a28078aff7d4e2cb41475137532560
 
-    # ghostscript most recent version as of 2024.03 was from 2024.03
+    # ghostscript most recent version as of 2025.03 was from 2025.03
   - name: GhostscriptDependency
     buildsystem: autotools
     sources:
       - type: archive
-        url:  https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10030/ghostscript-10.03.0.tar.gz
-        sha256:  6f2bc61023469fcf7c7c2d7f1bdd75b75f2b41836aa1d5e641396246d4abbb59
+        url: https://github.com/ArtifexSoftware/ghostpdl/archive/refs/tags/ghostpdl-10.05.0.tar.gz
+        sha256: 8fb8eb3c34646ac7f0287c7673ebbf3928b23e558f421edf4495b9881430a1d4
 
 # for network chart addon
-    # decorator most recent version as of 2024.03 was from 2022.01
-  - name: decoratorDependency
-    buildsystem: simple
-    build-commands:
-      - pip3 install --no-build-isolation .
-    sources:
-      - type: archive
-        url:  https://files.pythonhosted.org/packages/source/d/decorator/decorator-5.1.1.tar.gz
-        sha256:  637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330
-
-    # networkx most recent stable version as of 2024.03 was from 2023.10
+    # networkx most recent stable version as of 2025.03 was from 2024.10
   - name: networkxDependency
     buildsystem: simple
     build-commands:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url:  https://files.pythonhosted.org/packages/source/n/networkx/networkx-3.2.1.tar.gz
-        sha256:  9f1bb5cf3409bf324e0a722c20bdb4c20ee39bf1c30ce8ae499c8502b0b5e0c6
-  
+        url: https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz
+        sha256: 307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1
+
+# Gramps 6 requires orjson to run in flatpak, version 3.10.15 failed as of 2025-02, but 3.9.15 from 2024-02 succeeded in compiling
+  - name: orjsonDependency
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --no-build-isolation wheel orjson
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/6a/3a/225b65664b7de15cf706eda6ab65cb23e8f59c274d4457c4eeaa2d510980/orjson-3.9.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+        sha256: 10c57bc7b946cf2efa67ac55766e41764b66d40cbd9489041e637c1304400494
+
 # Gramps
   - name: Gramps
     buildsystem: simple
@@ -207,5 +194,5 @@ modules:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url:  https://github.com/gramps-project/gramps/archive/refs/tags/v5.2.4.tar.gz
-        sha256:  7d5f22db92c43cb7798b50837e95ee5da56154596d9dea3b96d2c5cd2e5f0cdd
+        url: https://github.com/gramps-project/gramps/archive/refs/tags/v6.0.0.tar.gz
+        sha256: 37a0f80ca536850dc458730f349c77045ee7b7243c2b9b635a46bee38469b057

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -177,15 +177,21 @@ modules:
         url: https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz
         sha256: 307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1
 
-# Gramps 6 requires orjson to run in flatpak, version 3.10.15 failed as of 2025-02, but 3.9.15 from 2024-02 succeeded in compiling
+# Gramps 6 requires orjson to run in flatpak
+# most recent version is from 2025.01 as of 2025.03
   - name: orjsonDependency
     buildsystem: simple
     build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --no-build-isolation wheel orjson
+      - pip3 install --prefix /app --no-deps orjson-*.whl
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/6a/3a/225b65664b7de15cf706eda6ab65cb23e8f59c274d4457c4eeaa2d510980/orjson-3.9.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-        sha256: 10c57bc7b946cf2efa67ac55766e41764b66d40cbd9489041e637c1304400494
+        only-arches: [x86_64]
+        url: https://files.pythonhosted.org/packages/fa/da/31543337febd043b8fa80a3b67de627669b88c7b128d9ad4cc2ece005b7a/orjson-3.10.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+        sha256: b48f59114fe318f33bbaee8ebeda696d8ccc94c9e90bc27dbe72153094e26f41
+      - type: file
+        only-arches: [aarch64]
+        url: https://files.pythonhosted.org/packages/48/b7/2622b29f3afebe938a0a9037e184660379797d5fd5234e5998345d7a5b43/orjson-3.10.15-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+        sha256: dba5a1e85d554e3897fa9fe6fbcff2ed32d55008973ec9a2b992bd9a65d2352d
 
 # Gramps
   - name: Gramps


### PR DESCRIPTION
  - update Gramps source and sha256 to 6.0.0
  - update Gnome Platform to 48
  - add orjson version 3.9.15 since 3.10.15 does not compile in flatpak
  - update exiv2 to 0.28.5
  - update gexiv2 to 0.14.3
  - update PILLOW to 11.1.0
  - update gspell to 1.14.0
  - removed python-fontconfig since its requirement got dropped in Gramps 5.2
  - update pyicu to 2.14
  - update graphviz to 12.2.1
  - update pygraphviz to 1.14
  - update ghostscriptpdl to 10.05.0
  - remove decorator dependency
  - update networkx to 3.4.2