### PR TITLE
bugfix--6.0.1-1 disables gspell due to crash

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Gramps flatpak 6.0.1-1
+  - disable gspell because it crashes Gramps when spell check is enabled while user works on Notes
+
 Gramps flatpak 6.0.1-0
   - update Gramps source to 6.0.1
 

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -69,13 +69,14 @@ modules:
       - type: patch
         path: goocanvas-3.0.0-gcc14.patch
 
+# temporarily comment out gspell because it crashes Gramps when enabled in settings and user works on Notes
     # Gspell most recent version as of 2025.03 was from 2024.09
-  - name: gspell
-    buildsystem: meson
-    sources: 
-      - type: archive
-        url: https://gitlab.gnome.org/GNOME/gspell/-/archive/1.14.0/gspell-1.14.0.tar.gz
-        sha256: 6ff11258569227c4ef0eaed0524e0c9f84308d34f89fbc49e5d961cdd832ac6a
+#  - name: gspell
+#    buildsystem: meson
+#    sources: 
+#      - type: archive
+#        url: https://gitlab.gnome.org/GNOME/gspell/-/archive/1.14.0/gspell-1.14.0.tar.gz
+#        sha256: 6ff11258569227c4ef0eaed0524e0c9f84308d34f89fbc49e5d961cdd832ac6a
 
 # following dependencies are for images and metadata
     # exiv2 most recent version as of 2025.03 was from 2025.02


### PR DESCRIPTION
https://gramps-project.org/bugs/view.php?id=13795
When spell check is enabled and user works on Notes (especially the Note Filter), Gramps often crashes. This crash locks the database. Cause is unknown at this time, so gspell is being temporarily disabled in the flatpak until this issue is resolved.