### PR TITLE
6.0.6--1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,10 @@
-Gramps flatpak 6.0.5--2
+Gramps flatpak 6.0.6--1
+  - update Gramps to 6.0.6
   - update Gnome Platform to 49
   - change ghostpdl 10.05 to ghostscript 10.06
   - update orjson dependency
   - changes to sort dependencies in manifests easier
+  - specify some build and run paths in flatpak
 
 Gramps flatpak 6.0.5--1
   - update Gramps source to 6.0.5

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Gramps flatpak 6.0.5--2
+  - update Gnome Platform to 49
+  - change ghostpdl 10.05 to ghostscript 10.06
+  - update orjson dependency
+  - changes to sort dependencies in manifests easier
+
 Gramps flatpak 6.0.5--1
   - update Gramps source to 6.0.5
 

--- a/DepsAddonNetworkChart.yml
+++ b/DepsAddonNetworkChart.yml
@@ -1,0 +1,14 @@
+# This manifest is to include dependencies for the Addon NetworkChart to work
+name: DepsAddonNetworkChart
+buildsystem: simple
+build-commands: []
+modules:
+# networkx most recent stable version as of 2025.03 was from 2024.10
+  - name: networkxDependency
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz
+        sha256: 307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -1,0 +1,81 @@
+# Core dependencies for Gramps
+name: DepsCore
+buildsystem: simple
+build-commands: []
+modules:
+# PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
+  - name: PILLOWDependency
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - type: archive
+        url:  https://files.pythonhosted.org/packages/f3/af/c097e544e7bd278333db77933e535098c259609c4eb3b85381109602fb5b/pillow-11.1.0.tar.gz
+        sha256:  368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20
+# Goocanvas is abandoned and the most recent update is from 2021.01.16
+  - name: GoocanvasDependency
+    buildsystem: autotools
+    config-opts:
+      - --prefix=/app
+    make-install-args:
+      - pyoverridesdir=/app/lib/python3.13/site-packages/gi/overrides
+      - typelibdir=/app/lib/girepository-1.0
+    sources:
+      - type: archive
+        url:  https://download.gnome.org/sources/goocanvas/3.0/goocanvas-3.0.0.tar.xz
+        sha256:  670a7557fe185c2703a14a07506156eceb7cea3b4bf75076a573f34ac52b401a
+      - type: patch
+        path: goocanvas-3.0.0-gcc14.patch
+# pyicu is a recommended dep for Gramps; most recent release as of 2025.03 was from 2024.10
+  - name: PyICUDependency
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/52/21/4e9b0a3ace3027fc63107fa2b5d6e66e321e104da071d787856962fbad52/PyICU-2.14.tar.gz
+        sha256: acc7eb92bd5c554ed577249c6978450a4feda0aa6f01470152b3a7b382a02132
+# graphviz is a recommended dep for Gramps; most recent version as of 2025.03 from 2024.12
+  - name: GraphVizDependency
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.1/graphviz-12.2.1.tar.gz
+        sha256: 242bc18942eebda6db4039f108f387ec97856fc91ba47f21e89341c34b554df8
+# pygraphviz allows graphviz to work with python; 1.14 most recent version 2024.09.29 as of 2025.03
+  - name: PyGraphVizDependency
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - type: archive
+        url: https://github.com/pygraphviz/pygraphviz/archive/refs/tags/pygraphviz-1.14.tar.gz
+        sha256:  d9a43f34b920367fa89a2598083b47db42a28078aff7d4e2cb41475137532560
+# ghostscript is recommended for Gramps; most recent version as of 2025.11 was from 2025.09
+  - name: GhostscriptDependency
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url:  https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10060/ghostscript-10.06.0.tar.gz
+        sha256:  5bd6da34794928cc7e616f288e32bd0be7f9a5ca2d3c206a0af2c19a4e3a318f
+# most recent version as of 2025.11 is from 2025.10
+  - name: orjsonDependency
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps orjson-*.whl
+    sources:
+      - type: file
+        only-arches: [x86_64]
+        url: https://files.pythonhosted.org/packages/aa/fd/d0733fcb9086b8be4ebcfcda2d0312865d17d0d9884378b7cffb29d0763f/orjson-3.11.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+        sha256:  1469d254b9884f984026bd9b0fa5bbab477a4bfe558bba6848086f6d43eb5e73
+      - type: file
+        only-arches: [aarch64]
+        url: https://files.pythonhosted.org/packages/55/b9/ae8d34899ff0c012039b5a7cb96a389b2476e917733294e498586b45472d/orjson-3.11.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+        sha256: 38aa9e65c591febb1b0aed8da4d469eba239d434c218562df179885c94e1a3ad
+# Gspell most recent version as of 2025.03 was from 2024.09
+  - name: gspell
+    buildsystem: meson
+    sources: 
+      - type: archive
+        url: https://gitlab.gnome.org/GNOME/gspell/-/archive/1.14.0/gspell-1.14.0.tar.gz
+        sha256: 6ff11258569227c4ef0eaed0524e0c9f84308d34f89fbc49e5d961cdd832ac6a

--- a/DepsImages.yml
+++ b/DepsImages.yml
@@ -1,0 +1,28 @@
+# following dependencies are for images and metadata related Gramps addons
+name: DepsImages
+buildsystem: simple
+build-commands: []
+modules:
+    # exiv2 most recent version as of 2025.03 was from 2025.02
+  - name: exiv2
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DEXIV2_ENABLE_BMFF=ON
+      - -DEXIV2_ENABLE_INIH=OFF
+    builddir: true
+    sources:
+      - type: archive
+        url:  https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.5.tar.gz
+        sha256: e1671f744e379a87ba0c984617406fdf8c0ad0c594e5122f525b2fb7c28d394d
+    # gexiv2 most recent version as of 2025.03 was from 2024.06
+    # gramps apparently needs introspection to use gexiv2
+  - name: gexiv2Dependency
+    buildsystem: meson
+    build-options:
+      env:
+        - -PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR=/app/share/gir-1.0
+        - -PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR=/app/lib/girepository-1.0
+    sources:
+      - type: archive
+        url:  https://gitlab.gnome.org/GNOME/gexiv2/-/archive/gexiv2-0.14.3/gexiv2-gexiv2-0.14.3.tar.gz
+        sha256:  5a7ea82effa9c812ac1518a1b4a22a15035d721b0b30cd4b8303228fd5b38e3c

--- a/DepsMaps.yml
+++ b/DepsMaps.yml
@@ -1,0 +1,29 @@
+# Dependencies for maps and coordinates in Gramps
+name: DepsMaps
+buildsystem: simple
+build-commands: []
+modules:
+# osmgpsmap dependency 1.2 as of 2023-06 requires libsoup 2.4. 
+   # Libsoup 2 is not in Gnome 44 runtime as of 2023-06, so libsoup needs a manual install until
+   # osmgpsmap gets updated to use a newer version of libsoup. Latest libsoup 2 is 2.74 from Oct 2022.
+  - name: libsoupDependency
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libsoup/2.74/libsoup-2.74.3.tar.xz
+        sha256: e4b77c41cfc4c8c5a035fcdc320c7bc6cfb75ef7c5a034153df1413fa1d92f13
+    # osmgpsmap is abandoned as of 2025.03 so most recent version was from 202102
+  - name: osmgpsmapDependency
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url:  https://github.com/nzjrs/osm-gps-map/releases/download/1.2.0/osm-gps-map-1.2.0.tar.gz
+        sha256:  ddec11449f37b5dffb4bca134d024623897c6140af1f9981a8acc512dbf6a7a5
+    # Gramps does not see geocodeglib in platform, needed for place coordinate addon
+    # appears to not have versioned releases anymore, last git edit as of 2025.03 was from 2024.03
+  - name: geocodeglibDependency
+    buildsystem: meson
+    sources:
+      - type: archive
+        url:  https://gitlab.gnome.org/GNOME/geocode-glib/-/archive/8f1b5a9149156a03f62dfea14780e8fee030506d/geocode-glib-8f1b5a9149156a03f62dfea14780e8fee030506d.tar.gz
+        sha256:  f4ea933937633d6e33607945c9ca45070628e8545be0ea502b59f959932e8b26

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dependencies added to the flatpak
 - goocanvas
 - networkx
 
-To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github or at the flathub Gramps flatpak github.
+To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github.
 
 https://github.com/gramps-project/flatpak
 
@@ -38,6 +38,6 @@ with Gramps 5.1 and earlier is ~/.gramps, while the required directories for dat
 of Gramps 5.2 are xdg-data, xdg-config, xdg-cache. Once flathub stops blocking these directories, we can remove home
 directory access and go back to xdg access.
 
-Also, the old version of Berkeley Database (BSDDB) that was included with the Gramps 5.0 and 5.1 flatpaks will be dropped for 5.2.
+Also, the old version of Berkeley Database (BSDDB3) that was included with the Gramps 5.0 and 5.1 flatpaks was dropped starting with Gramps 5.2. An old archived flatpak with BSDDB3 is available at the gramps-project github https://github.com/gramps-project/flatpak/releases/tag/v5.1.6-1 to facilitate the conversion of old Gramps databases from BSDDB3 to the current SQLite.
 
 Please make regular full backups of your important genealogy files, and include any attached media files for your genealogy in your backups for your convenience.

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -64,5 +64,5 @@ modules:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url: https://github.com/gramps-project/gramps/archive/refs/tags/v6.0.5.tar.gz
-        sha256: 1295fe352669cdf419d762445db1d26ba5492da30c0a78fef278856eda9cc680
+        url: https://github.com/gramps-project/gramps/archive/refs/tags/v6.0.6.tar.gz
+        sha256: a1812a9b02e69dc49a9cdbc1b628f0af6c34115f5134d66f02e36f3fe75b2b77

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -1,7 +1,7 @@
 app-id: org.gramps_project.Gramps
 # flatpak-builder will not take hyphen in com.gramps-project.Gramps
 runtime: org.gnome.Platform
-runtime-version: '48'
+runtime-version: '49'
 sdk: org.gnome.Sdk
 command: gramps
 # to force an archive flatpak to use system locale instead of English. Not needed for flathub packages.
@@ -28,12 +28,17 @@ finish-args:
   - --share=ipc
 #needs network access for maps
   - --share=network
-
+# set the environment for app when run
+  - --env=PYTHONPATH=/app/plugins/site-packages
+  - --env=GI_TYPELIB_PATH=/app/lib/girepository-1.0
+  - --env=PYOVERRIDES_DIRECTORY=/app/lib/python3.13/site-packages/gi/overrides
 build-options:
   env:
     PIP_PREFIX: /app
     PIP_DISABLE_PIP_VERSION_CHECK: "1"
-
+    PYTHONPATH: /app/plugins/site-packages
+    GI_TYPELIB_PATH: /app/lib/girepository-1.0
+    PYOVERRIDES_DIRECTORY: /app/lib/python3.13/site-packages/gi/overrides
 cleanup:
   - '*.a'
   - '*.la'
@@ -43,144 +48,15 @@ cleanup:
   - /lib/cmake
   - /share/gir-1.0
   - /share/man
-
 modules:
-# PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
-  - name: PILLOWDependency
-    buildsystem: simple
-    build-commands:
-      - pip3 install --no-build-isolation .
-    sources:
-      - type: archive
-        url:  https://files.pythonhosted.org/packages/f3/af/c097e544e7bd278333db77933e535098c259609c4eb3b85381109602fb5b/pillow-11.1.0.tar.gz
-        sha256:  368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20
-# Goocanvas is abandoned and the most recent update is from 2021.01.16.
-  - name: GoocanvasDependency
-    buildsystem: autotools
-    config-opts:
-      - --prefix=/app
-    make-install-args:
-      - pyoverridesdir=/app/lib/python3.12/site-packages/gi/overrides
-      - typelibdir=/app/lib/girepository-1.0
-    sources:
-      - type: archive
-        url:  https://download.gnome.org/sources/goocanvas/3.0/goocanvas-3.0.0.tar.xz
-        sha256:  670a7557fe185c2703a14a07506156eceb7cea3b4bf75076a573f34ac52b401a
-      - type: patch
-        path: goocanvas-3.0.0-gcc14.patch
-# Gspell most recent version as of 2025.03 was from 2024.09
-  - name: gspell
-    buildsystem: meson
-    sources: 
-      - type: archive
-        url: https://gitlab.gnome.org/GNOME/gspell/-/archive/1.14.0/gspell-1.14.0.tar.gz
-        sha256: 6ff11258569227c4ef0eaed0524e0c9f84308d34f89fbc49e5d961cdd832ac6a
-# following dependencies are for images and metadata related Gramps addons
-    # exiv2 most recent version as of 2025.03 was from 2025.02
-  - name: exiv2
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DEXIV2_ENABLE_BMFF=ON
-      - -DEXIV2_ENABLE_INIH=OFF
-    builddir: true
-    sources:
-      - type: archive
-        url:  https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.5.tar.gz
-        sha256: e1671f744e379a87ba0c984617406fdf8c0ad0c594e5122f525b2fb7c28d394d
-    # gexiv2 most recent version as of 2025.03 was from 2024.06
-    # gramps apparently needs introspection to use gexiv2
-  - name: gexiv2Dependency
-    buildsystem: meson
-    build-options:
-      env:
-        - -PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR=/app/share/gir-1.0
-        - -PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR=/app/lib/girepository-1.0
-    sources:
-      - type: archive
-        url:  https://gitlab.gnome.org/GNOME/gexiv2/-/archive/gexiv2-0.14.3/gexiv2-gexiv2-0.14.3.tar.gz
-        sha256:  5a7ea82effa9c812ac1518a1b4a22a15035d721b0b30cd4b8303228fd5b38e3c
-# Map related dependencies
-   # osmgpsmap dependency 1.2 as of 2023-06 requires libsoup 2.4. 
-   # Libsoup 2 is not in Gnome 44 runtime as of 2023-06, so libsoup needs a manual install until
-   # osmgpsmap gets updated to use a newer version of libsoup. Latest libsoup 2 is 2.74 from Oct 2022.
-  - name: libsoupDependency
-    buildsystem: meson
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libsoup/2.74/libsoup-2.74.3.tar.xz
-        sha256: e4b77c41cfc4c8c5a035fcdc320c7bc6cfb75ef7c5a034153df1413fa1d92f13
-    # osmgpsmap is abandoned as of 2025.03 so most recent version was from 202102
-  - name: osmgpsmapDependency
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url:  https://github.com/nzjrs/osm-gps-map/releases/download/1.2.0/osm-gps-map-1.2.0.tar.gz
-        sha256:  ddec11449f37b5dffb4bca134d024623897c6140af1f9981a8acc512dbf6a7a5
-    # Gramps does not see geocodeglib in platform, needed for place coordinate addon
-    # appears to not have versioned releases anymore, last git edit as of 2025.03 was from 2024.03
-  - name: geocodeglibDependency
-    buildsystem: meson
-    sources:
-      - type: archive
-        url:  https://gitlab.gnome.org/GNOME/geocode-glib/-/archive/8f1b5a9149156a03f62dfea14780e8fee030506d/geocode-glib-8f1b5a9149156a03f62dfea14780e8fee030506d.tar.gz
-        sha256:  f4ea933937633d6e33607945c9ca45070628e8545be0ea502b59f959932e8b26
-# pyicu is a recommended dep for Gramps; most recent release as of 2025.03 was from 2024.10
-  - name: PyICUDependency
-    buildsystem: simple
-    build-commands:
-      - pip3 install --no-build-isolation .
-    sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/52/21/4e9b0a3ace3027fc63107fa2b5d6e66e321e104da071d787856962fbad52/PyICU-2.14.tar.gz
-        sha256: acc7eb92bd5c554ed577249c6978450a4feda0aa6f01470152b3a7b382a02132
-# graphviz is a recommended dep for Gramps; most recent version as of 2025.03 from 2024.12
-  - name: GraphVizDependency
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.1/graphviz-12.2.1.tar.gz
-        sha256: 242bc18942eebda6db4039f108f387ec97856fc91ba47f21e89341c34b554df8
-# pygraphviz allows graphviz to work with python; 1.14 most recent version 2024.09.29 as of 2025.03
-  - name: PyGraphVizDependency
-    buildsystem: simple
-    build-commands:
-      - pip3 install --no-build-isolation .
-    sources:
-      - type: archive
-        url: https://github.com/pygraphviz/pygraphviz/archive/refs/tags/pygraphviz-1.14.tar.gz
-        sha256:  d9a43f34b920367fa89a2598083b47db42a28078aff7d4e2cb41475137532560
-# ghostscript is recommended for Gramps; most recent version as of 2025.03 was from 2025.03
-  - name: GhostscriptDependency
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url: https://github.com/ArtifexSoftware/ghostpdl/archive/refs/tags/ghostpdl-10.05.0.tar.gz
-        sha256: 8fb8eb3c34646ac7f0287c7673ebbf3928b23e558f421edf4495b9881430a1d4
+# manifest below is for core Gramps dependencies
+  - DepsCore.yml
+# manifest below is for image and exiv metadata
+  - DepsImages.yml
+# manifest below is for Map related dependencies
+  - DepsMaps.yml
 # for network chart addon
-    # networkx most recent stable version as of 2025.03 was from 2024.10
-  - name: networkxDependency
-    buildsystem: simple
-    build-commands:
-      - pip3 install --no-build-isolation .
-    sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz
-        sha256: 307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1
-# Gramps 6 requires orjson to run in flatpak
-# most recent version is from 2025.01 as of 2025.03
-  - name: orjsonDependency
-    buildsystem: simple
-    build-commands:
-      - pip3 install --no-deps orjson-*.whl
-    sources:
-      - type: file
-        only-arches: [x86_64]
-        url: https://files.pythonhosted.org/packages/fa/da/31543337febd043b8fa80a3b67de627669b88c7b128d9ad4cc2ece005b7a/orjson-3.10.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-        sha256: b48f59114fe318f33bbaee8ebeda696d8ccc94c9e90bc27dbe72153094e26f41
-      - type: file
-        only-arches: [aarch64]
-        url: https://files.pythonhosted.org/packages/48/b7/2622b29f3afebe938a0a9037e184660379797d5fd5234e5998345d7a5b43/orjson-3.10.15-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-        sha256: dba5a1e85d554e3897fa9fe6fbcff2ed32d55008973ec9a2b992bd9a65d2352d
+  - DepsAddonNetworkChart.yml
 # Gramps
   - name: Gramps
     buildsystem: simple


### PR DESCRIPTION
  - update Gramps to 6.0.6
  - update Gnome Platform to 49
  - change ghostpdl 10.05 to ghostscript 10.06
  - update orjson dependency
  - changes to sort dependencies in manifests easier
  - specify some build and run paths in flatpak