### PR TITLE
6.0.8--1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+Gramps flatpak 6.0.8--1
+  - update Gramps to 6.0.8
+  - add python-imagesize
+  - add ttf-freefonts
+  - add python-fontconfig
+  - add pycountry
+
 Gramps flatpak 6.0.7--1
   - update Gramps to 6.0.7
 

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -1,8 +1,29 @@
 # Core dependencies for Gramps
+# some code adapted from AI (Grok) recommendations
 name: DepsCore
 buildsystem: simple
 build-commands: []
 modules:
+# ttf-freefonts recommended at Gramps 6.0.8 README
+  - name: ttf-freefonts
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/share/fonts/truetype/freefont
+      - install -m 644 *.ttf /app/share/fonts/truetype/freefont/
+      - install -m 644 README /app/share/doc/gnu-freefont/ || true
+    sources:
+      - type: archive
+        url:  https://ftp.gnu.org/gnu/freefont/freefont-ttf-20051206.tar.gz
+        sha256:  247af4ab5be736df63d9572665ea341251e8afaf924f384ddcb18c3549113ed3
+# python-fontconfig optional for symbols and reports, most recent version as of 2026.04 is from 2025.09
+  - name: python-fontconfig
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - type: archive
+        url:  https://files.pythonhosted.org/packages/20/59/99db03443f584b6d14bb635ef9f849dae7966792471dee9bf50ae2308f07/python_fontconfig-0.6.2.post1.tar.gz
+        sha256:   4837290305613710cf6c515db8923284da06e4f48a549d2fe8e2d4276aed3e73 
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple
@@ -79,3 +100,12 @@ modules:
       - type: archive
         url: https://gitlab.gnome.org/GNOME/gspell/-/archive/1.14.0/gspell-1.14.0.tar.gz
         sha256: 6ff11258569227c4ef0eaed0524e0c9f84308d34f89fbc49e5d961cdd832ac6a
+# pycountry for internationalization, most recent version as of 2026.04 is from 2026.02
+  - name: pycountry
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps pycountry-*.whl
+    sources:
+      - type: file
+        url:  https://files.pythonhosted.org/packages/9c/42/7703bd45b62fecd44cd7d3495423097e2f7d28bc2e99e7c1af68892ab157/pycountry-26.2.16-py3-none-any.whl
+        sha256:  115c4baf7cceaa30f59a4694d79483c9167dbce7a9de4d3d571c5f3ea77c305a

--- a/DepsImages.yml
+++ b/DepsImages.yml
@@ -26,3 +26,12 @@ modules:
       - type: archive
         url:  https://gitlab.gnome.org/GNOME/gexiv2/-/archive/gexiv2-0.14.3/gexiv2-gexiv2-0.14.3.tar.gz
         sha256:  5a7ea82effa9c812ac1518a1b4a22a15035d721b0b30cd4b8303228fd5b38e3c
+    # imagesize most recent version as of 2026.04 was from 2026.03
+  - name: python-imagesize
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps imagesize-*.whl
+    sources:
+      - type: file
+        url:  https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl
+        sha256:  5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
-# org.gramps_project.Gramps 
-The Gramps Project strives to produce a genealogy program that is both intuitive for hobbyists and feature-complete for professional genealogists.  The website for Gramps is at https://gramps-project.org/
+# Gramps Flatpak
+These are the manifest and data files required to make a Gramps Flatpak
+
+The flatpak is available on flathub at https://flathub.org/apps/details/org.gramps_project.Gramps
+The Gramps flatpak contains dependencies and works with flathub runtimes to work independently regardless of the linux distribution.  There are also dependencies for some third party add-ons like Graphview and Network Chart.
 
 # List of Included Dependencies
-Dependencies confirmed in the Gnome flatpak platform:
+Dependencies confirmed in the Gnome flatpak platform (Gnome 49 as of Gramps 6.0.8--1 flatpak):
 - python3
 - gtk
 - pygobject
 - cairo
 - pango
 - pangocairo
+- librsvg2
 
 Dependencies added to the flatpak
 - orjson
@@ -22,6 +26,10 @@ Dependencies added to the flatpak
 - geocodeglib
 - goocanvas
 - networkx
+- python-imagesize
+- TTF-Freefonts
+- python-fontconfig
+- pycountry
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github.
 
@@ -29,15 +37,8 @@ https://github.com/gramps-project/flatpak
 
 https://github.com/flathub/org.gramps_project.Gramps
 
-***Please Note***
-Posting new issues to drop home access can not be complied with at this time. Both attempts to use specific xdg directories have caused problems for users of the Gramps flatpak.
-At this time, flathub rules blocking data directory access prevents users from choosing to go between a flatpak
-installation and a system installation, which causes data loss for some users. Even using persist like flathub says
-instead of filesystem can cause data loss for users moving from the flatpak to a system install. The required directories for databases started 
-with Gramps 5.1 and earlier is ~/.gramps, while the required directories for databases started with a system installation 
-of Gramps 5.2 are xdg-data, xdg-config, xdg-cache. Once flathub stops blocking these directories, we can remove home
-directory access and go back to xdg access.
-
 Also, the old version of Berkeley Database (BSDDB3) that was included with the Gramps 5.0 and 5.1 flatpaks was dropped starting with Gramps 5.2. An old archived flatpak with BSDDB3 is available at the gramps-project github https://github.com/gramps-project/flatpak/releases/tag/v5.1.6-1 to facilitate the conversion of old Gramps databases from BSDDB3 to the current SQLite.
+
+In 2021, Gnu RCS 5.10.0 could be compiled into the flatpak. The newer tar.lz archives and some formatting issues now make RCS fail to compile.  If anyone can get it to compile into the Gramps flatpak, you are welcome to submit a PR to https://github.com/gramps-project/flatpak
 
 Please make regular full backups of your important genealogy files, and include any attached media files for your genealogy in your backups for your convenience.

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -63,6 +63,6 @@ modules:
     build-commands:
       - pip3 install --no-build-isolation .
     sources:
-      - type: archive
-        url: https://github.com/gramps-project/gramps/archive/refs/tags/v6.0.7.tar.gz
-        sha256: 5b1d4d63f2abd072330a26d26db161a3c05f9a7d08bab07f29ef5647beafcb0a
+      - type: git
+        url: https://github.com/gramps-project/gramps.git
+        tag: v6.0.8


### PR DESCRIPTION
  - update Gramps to 6.0.8
  - add python-imagesize
  - add ttf-freefonts
  - add python-fontconfig
  - add pycountry

Gnome Platform has to remain at 49 for Gramps 6.0.8 until Gramps bug https://gramps-project.org/bugs/view.php?id=14183 gets fixed in Gramps 6.0.9. Then Gramps should be stable on Gnome Platform 50.